### PR TITLE
"fix for deleting /hats, gloves and next parented items from player model on end emotes" in courtesy of _GamerX from alliedmods.net

### DIFF
--- a/addons/sourcemod/scripting/fortnite_emotes_extended.sp
+++ b/addons/sourcemod/scripting/fortnite_emotes_extended.sp
@@ -606,9 +606,13 @@ void StopEmote(int client)
 	int iEmoteEnt = EntRefToEntIndex(g_iEmoteEnt[client]);
 	if (iEmoteEnt && iEmoteEnt != INVALID_ENT_REFERENCE && IsValidEntity(iEmoteEnt))
 	{
-		AcceptEntityInput(client, "ClearParent", client, client, 0);
-		AcceptEntityInput(iEmoteEnt, "Kill");
-		
+		char emoteEntName[50];
+		GetEntPropString(iEmoteEnt, Prop_Data, "m_iName", emoteEntName, sizeof(emoteEntName));
+		SetVariantString(emoteEntName);
+		AcceptEntityInput(client, "ClearParent", iEmoteEnt, iEmoteEnt, 0);
+		DispatchKeyValue(iEmoteEnt, "OnUser1", "!self,Kill,,1.0,-1");
+		AcceptEntityInput(iEmoteEnt, "FireUser1");
+
 		ResetCam(client);
 		WeaponUnblock(client);
 		SetEntityMoveType(client, MOVETYPE_WALK);
@@ -645,8 +649,12 @@ void TerminateEmote(int client)
 	int iEmoteEnt = EntRefToEntIndex(g_iEmoteEnt[client]);
 	if (iEmoteEnt && iEmoteEnt != INVALID_ENT_REFERENCE && IsValidEntity(iEmoteEnt))
 	{
-		AcceptEntityInput(client, "ClearParent", client, client, 0);
-		AcceptEntityInput(iEmoteEnt, "Kill");
+		char emoteEntName[50];
+		GetEntPropString(iEmoteEnt, Prop_Data, "m_iName", emoteEntName, sizeof(emoteEntName));
+		SetVariantString(emoteEntName);
+		AcceptEntityInput(client, "ClearParent", iEmoteEnt, iEmoteEnt, 0);
+		DispatchKeyValue(iEmoteEnt, "OnUser1", "!self,Kill,,1.0,-1");
+		AcceptEntityInput(iEmoteEnt, "FireUser1");
 
 		g_iEmoteEnt[client] = 0;
 		g_bClientDancing[client] = false;


### PR DESCRIPTION
code taken from https://forums.alliedmods.net/showpost.php?p=2674395&postcount=97 written by _GamerX

this change fixes the deletion of entities that are attached to players like gloves, hats etc. when using dances/emotes. this makes it so that the plugin is compatible with every plugin that create attachments to player entity, without the need for modifying them to use forwards (such as https://forums.alliedmods.net/showthread.php?t=299977 / https://github.com/kgns/gloves)

this had been sitting in the alliedmodders forum thread for a long time, why it wasn't added before beats me.