### PR TITLE
fix include error

### DIFF
--- a/addons/sourcemod/scripting/include/fnemotes.inc
+++ b/addons/sourcemod/scripting/include/fnemotes.inc
@@ -20,8 +20,19 @@ native bool fnemotes_IsClientEmoting(int client);
  */
 forward void fnemotes_OnEmote(int client);
 
+public SharedPlugin:__pl_fnemotes =
+{
+    name = "fnemotes",
+    file = "fortnite_emotes_extended.smx",
+    #if defined REQUIRE_PLUGIN
+    required = 1,
+    #else
+    required = 0,
+    #endif
+};
 
 public void __pl_fnemotes_SetNTVOptional()
 {
 	MarkNativeAsOptional("fnemotes_IsClientEmoting");
+	MarkNativeAsOptional("fnemotes_OnEmote");
 }


### PR DESCRIPTION
Fixes "Native fnemotes_IsClientEmoting was not found" error, forgot to set the REQUIRED_PLUGIN defines when first creating the include file in #2 